### PR TITLE
Fixed case when the soundbar closes the connection

### DIFF
--- a/temescal/__init__.py
+++ b/temescal/__init__.py
@@ -91,6 +91,13 @@ class temescal:
             except Exception:
                 self.connect()
 
+            if len(data) == 0: # the soundbar closed the connection, recreate it
+                self.socket.shutdown(socket.SHUT_RDWR)
+                self.socket.close()
+                self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self.connect()
+                continue
+
             if data[0] == 0x10:
                 data = self.socket.recv(4)
                 length = struct.unpack(">I", data)[0]


### PR DESCRIPTION
It looks like after 5 min of inactivity (no command from the library) the soundbar closes the connection itself (typically after 5min).

After that the `data = self.socket.recv(1)` call returns empty string so the line `if data[0] == 0x10:` after that generates an exception:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/site-packages/temescal/__init__.py", line 93, in listen
    if data[0] == 0x10:
IndexError: index out of range
```

Fixed that by closing and recreating the socket when that happens.